### PR TITLE
fix: return the right extension of bin without errors

### DIFF
--- a/src/helpers/contentProcessing.ts
+++ b/src/helpers/contentProcessing.ts
@@ -1,3 +1,5 @@
+import { extname } from "path";
+
 import { BinError } from "../misc/BinError";
 import { createBin } from "./createBin";
 import { logError } from "./logError";
@@ -109,9 +111,7 @@ export async function processContent(source: string, maxLines: number): Promise<
 
 			if (!bin) {
 				const link = await createBin(result.content, result.lang)
-					.then((url) => (ext = "txt"): string =>
-						`<${url.slice(0, url.endsWith("txt") ? -3 : -result.lang!.length)}${ext}>`,
-					)
+					.then((url) => (ext = "txt"): string => `<${url.replace(extname(url), `.${ext}`)}>`)
 					// eslint-disable-next-line @typescript-eslint/no-loop-func
 					.catch((e: Error) => {
 						errors++;

--- a/test/helpers/contentProcessing.test.ts
+++ b/test/helpers/contentProcessing.test.ts
@@ -40,8 +40,8 @@ describe(processContent, () => {
 	});
 
 	it("should replace duplicated codes by the same bin url with different extension", async () => {
-		const [first, last] = (await processContent("```jss\na\nb\nc``` ```ts\na\nb\nc```", MAX_LINES))!.split(" ", 2);
-		expect(last).toEqual(`${first.slice(0, -4)}ts>`);
+		const [first, last] = (await processContent("```python\na\nb``` ```py\na\nb```", 1))!.split(" ", 2);
+		expect(first).toEqual(`${last.slice(0, -3)}python>`);
 	});
 
 	it("should make the corrects changes", async () => {


### PR DESCRIPTION
Fix this bug :
![image](https://user-images.githubusercontent.com/48163546/104206935-726f6b00-5430-11eb-8eec-e612bd877d6a.png)
