### PR TITLE
feat: add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git/
+.github/
+.vscode/
+
+.editorconfig
+.env.example
+.gitattributes
+.gitignore
+Dockerfile
+LICENSE
+README.md
+rtdbin-docker-compose.yml
+
+src/**/\_\_tests\_\_

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:17-alpine3.14
 
-ENTRYPOINT yarn start
-WORKDIR /usr/local/lib/rtb-bot
-LABEL org.opencontainers.image.source https://github.com/readthedocs-fr/bin-client-discord
-
-COPY . /usr/local/lib/rtb-bot
+WORKDIR /rtb-bot
+COPY . .
 RUN yarn install; yarn build
+
+ENTRYPOINT yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:17-alpine3.14
+
+ENTRYPOINT yarn start
+WORKDIR /usr/local/lib/rtb-bot
+LABEL org.opencontainers.image.source https://github.com/readthedocs-fr/bin-client-discord
+
+COPY . /usr/local/lib/rtb-bot
+RUN yarn install; yarn build


### PR DESCRIPTION
Quickly add a Dockerfile, heavily inspired from the one of bin-server, in order to make machine migration easier.

This Dockerfile is the one used in production for now, so I think we could merge it to the main branch.

### TODOs

- [x] Remove useless LABEL line
- [x] Avoid to copy .git/ folder into the docker image container
- [x] Create a .dockerignore
- [x] ~~Create a VOLUME?~~ (useless)
- [x] ~~Add an HEALTHCHECK line?~~ (maybe later, not really useful for now)
- [x] ~~Create a docker compose file?~~ (to do later, will open an issue for that)